### PR TITLE
Create expo.yml GitAction and add build-status badge to home page

### DIFF
--- a/.github/workflows/expo.yml
+++ b/.github/workflows/expo.yml
@@ -1,0 +1,16 @@
+name: Expo Build
+on:  [push]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - uses: expo/expo-github-action@v5
+        with:
+          expo-version: 3.x
+      - run: yarn install

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![Expo Build](https://github.com/startach/haprev/workflows/Expo%20Build/badge.svg)
+
 # React Native & Redux Application - מהפכה של שמחה
 **אפליקציה לעידוד התנדבויות בבתי חולים**
 


### PR DESCRIPTION
This is the minimalist's CI.

Can later enhance it to create APK and IPA files and to publish to Expo repository.